### PR TITLE
fix(chart): honor persistence toggles and pin helm-docs rev

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
     - id: helmlint
   - repo: https://github.com/norwoodj/helm-docs
-    rev:  ""
+    rev: v1.14.2
     hooks:
       - id: helm-docs
         args:

--- a/charts/unifi-network-application/templates/deployment.yaml
+++ b/charts/unifi-network-application/templates/deployment.yaml
@@ -111,7 +111,7 @@ spec:
       dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      dnsPolicy: {{ .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy | default "ClusterFirst" }}
 
       containers:
         - name: {{ include "template.fullname" . }}-app

--- a/charts/unifi-network-application/templates/persistentvolumeclaim.yaml
+++ b/charts/unifi-network-application/templates/persistentvolumeclaim.yaml
@@ -1,10 +1,11 @@
+{{- if .Values.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "template.fullname" . }}
   labels:
     {{- include "template.labels" . | nindent 4 }}
-  namespace: {{ default .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | default "ReadWriteOnce" }}
@@ -14,20 +15,25 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size }}
+{{- end }}
+{{- if and .Values.persistence.enabled .Values.mongodb.persistence.enabled }}
 ---
+{{- end }}
+{{- if .Values.mongodb.persistence.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "template.fullname" . }}-mongodb
   labels:
     {{- include "template.labels" . | nindent 4 }}
-  namespace: {{ default .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   accessModes:
-    - {{ .Values.persistence.accessMode | default "ReadWriteOnce" }}
-  {{- with .Values.persistence.storageClass }}
+    - {{ .Values.mongodb.persistence.accessMode | default "ReadWriteOnce" }}
+  {{- with .Values.mongodb.persistence.storageClass }}
   storageClassName: {{ . }}
   {{- end }}
   resources:
     requests:
-      storage: {{ .Values.persistence.size }}
+      storage: {{ .Values.mongodb.persistence.size }}
+{{- end }}

--- a/charts/unifi-network-application/values.yaml
+++ b/charts/unifi-network-application/values.yaml
@@ -65,6 +65,9 @@ additionalVolumeMounts: []
 nodeSelector: {}
 tolerations: []
 affinity: {}
+hostNetwork: false
+dnsPolicy: ClusterFirst
+dnsConfig: {}
 
 # Settigns related to the embedded MongoDB instance
 mongodb:


### PR DESCRIPTION
## Summary

- Honor persistence toggles for PVC creation:
  - app PVC only when `persistence.enabled=true`
  - MongoDB PVC only when `mongodb.persistence.enabled=true`
- Use `mongodb.persistence.*` values for MongoDB PVC (size/accessMode/storageClass)
- Ensure `dnsPolicy` has a safe default (`ClusterFirst`)
- Add default values in `values.yaml`:
  - `hostNetwork: false`
  - `dnsPolicy: ClusterFirst`
  - `dnsConfig: {}`
- Pin pre-commit helm-docs hook to immutable tag `v1.14.2`

## Validation

- `helm lint charts/unifi-network-application`
- `helm template` with persistence disabled (no PVCs rendered)
- `helm template` with `mongodb.persistence.size=20Gi` (MongoDB PVC rendered with 20Gi)
- `pre-commit validate-config .pre-commit-config.yaml`